### PR TITLE
[FE] modify the border radius and margin of the BsArrowRightShort to …

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -171,7 +171,7 @@ const Footer = () => {
             />
             <BsArrowRightShort
               size={50}
-              className={`${transition} rounded-sm bg-blue px-2 text-white hover:bg-black`}
+              className={`${transition} rounded-r-sm bg-blue px-2 text-white hover:bg-black -ml-[1px]`}
             />
           </div>
         </article>


### PR DESCRIPTION
Instead of adding border radius to all the corners of the BsArrowRightShort, I rather apply it on the top-right and bottom right and give a negative margin to pull it back and make it look like the input and the arrow are one together, making the UI looks nicer